### PR TITLE
Refactor authentication to use SpringSecurity

### DIFF
--- a/back-end/src/main/java/com/emailrelay/config/SecurityConfig.java
+++ b/back-end/src/main/java/com/emailrelay/config/SecurityConfig.java
@@ -31,15 +31,11 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/auth/signup/**",
-                                "/api/auth/login/**",
+                                "/api/auth/send-verification-code",
+                                "/api/auth/login",
                                 "/api/auth/refresh",
-                                "/api/webhook/**"
-                        ).permitAll()
-                        .requestMatchers(
                                 "/api/users/exists/**",
-                                "/api/users/send-verification-code",
-                                "/api/users/verify-code"
+                                "/api/webhook/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/back-end/src/main/java/com/emailrelay/controller/AuthController.java
+++ b/back-end/src/main/java/com/emailrelay/controller/AuthController.java
@@ -1,0 +1,166 @@
+package com.emailrelay.controller;
+
+import com.emailrelay.dto.ApiResponse;
+import com.emailrelay.dto.AuthToken;
+import com.emailrelay.service.AuthService;
+import com.emailrelay.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+    private final UserService userService;
+
+    /**
+     * 회원가입/로그인을 위한 인증코드 발송
+     * @param username
+     * @return
+     */
+    @PostMapping("/send-verification-code")
+    public ResponseEntity<ApiResponse<Void>> sendVerificationCode(@RequestParam String username) {
+        authService.sendVerificationCode(username);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    /**
+     * 인증코드 유효성 검증
+     * @param username
+     * @param code
+     * @return
+     */
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<String>> verifyCodeToLogin(HttpServletResponse response, @RequestParam String username, @RequestParam String code) {
+        if (!userService.existsByUsername(username)) {
+            userService.createEmailUser(username);
+        }
+        boolean result = authService.verifyCode(username, code);
+        if (result) {
+            AuthToken authToken = userService.login(username);
+
+            Long userId = authService.getUserIdFromToken(authToken.accessToken());
+
+            // Set authentication in SecurityContext
+            UsernamePasswordAuthenticationToken authentication
+                    = new UsernamePasswordAuthenticationToken(userId, null, new ArrayList<>());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.info("User logged in : {}", username);
+
+            setTokenCookie(response, authToken.refreshToken(), authService.getRefreshTokenTTL());
+            return ResponseEntity.ok(ApiResponse.success(authToken.accessToken()));
+        }
+        return ResponseEntity.ok(ApiResponse.fail("Wrong code"));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<String>> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+        // get access token from request header
+        String accessToken = extractTokenFromHeader(request);
+
+        // verify access token
+        if (accessToken != null && authService.validateToken(accessToken)) {
+            // if it is valid, return.
+            return ResponseEntity.ok(ApiResponse.success(accessToken));
+        }
+
+        // it is invalid or not exists token, get refresh token from http only cookies
+        String refreshToken = extractTokenFromCookie(request);
+
+        if (refreshToken == null || !authService.validateToken(refreshToken)) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.fail("Required login"));
+        }
+
+        // grant access token and return it
+        Long userId = authService.getUserIdFromToken(refreshToken);
+        String username = authService.getUsernameFromToken(refreshToken);
+
+        // Validate refresh token exists in Redis
+        if (!authService.validateRefreshTokenInCache(userId, refreshToken)) {
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.fail("Required login"));
+        }
+
+        String newAccessToken = authService.generateAccessToken(userId, username);
+
+        return ResponseEntity.ok(ApiResponse.success(newAccessToken));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = extractTokenFromCookie(request);
+
+        if (refreshToken != null && authService.validateToken(refreshToken)) {
+            try {
+                Long userId = authService.getUserIdFromToken(refreshToken);
+                authService.removeRefreshToken(userId);
+                SecurityContextHolder.clearContext();
+            } catch (Exception e) {
+                log.warn("Failed to remove refresh token from cache", e);
+            }
+        }
+
+        // Clear refresh token cookie
+        clearTokenCookie(response);
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    private String extractTokenFromHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    private String extractTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() != null) {
+            for (var cookie : request.getCookies()) {
+                if ("refreshToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    private void setTokenCookie(HttpServletResponse response, String token, Long ttl) {
+        response.addHeader("Set-Cookie",
+                "refreshToken=" + token +
+                        "; Path=/" +
+                        "; HttpOnly" +
+                        "; Secure" +
+                        "; SameSite=Strict" +
+                        "; Max-Age=" + (ttl));
+        // (7 * 24 * 60 * 60)); // 7일
+    }
+
+    private void clearTokenCookie(HttpServletResponse response) {
+        response.addHeader("Set-Cookie",
+                "refreshToken=" +
+                        "; Path=/" +
+                        "; HttpOnly" +
+                        "; Secure" +
+                        "; SameSite=Strict" +
+                        "; Max-Age=0");
+    }
+}

--- a/back-end/src/main/java/com/emailrelay/controller/UserController.java
+++ b/back-end/src/main/java/com/emailrelay/controller/UserController.java
@@ -1,7 +1,6 @@
 package com.emailrelay.controller;
 
 import com.emailrelay.dto.ApiResponse;
-import com.emailrelay.service.AuthService;
 import com.emailrelay.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
-    private final AuthService authService;
 
     /**
      * Check if username exists
@@ -26,32 +24,6 @@ public class UserController {
         boolean exists = userService.existsByUsername(username);
 
         return ResponseEntity.ok(ApiResponse.success(exists));
-    }
-
-    /**
-     * 회원가입/로그인을 위한 인증코드 발송
-     * @param username
-     * @return
-     */
-    @PostMapping("/send-verification-code")
-    public ResponseEntity<ApiResponse<Void>> sendVerificationCode(@RequestParam String username) {
-        authService.sendVerificationCode(username);
-        return ResponseEntity.ok(ApiResponse.success());
-    }
-
-    /**
-     * 인증코드 유효성 검증
-     * @param username
-     * @param code
-     * @return
-     */
-    @PostMapping("/verify-code")
-    public ResponseEntity<ApiResponse<Boolean>> verifyCode(@RequestParam String username, @RequestParam String code) {
-        if (!userService.existsByUsername(username)) {
-           userService.createEmailUser(username);
-        }
-        Boolean result = authService.verifyCode(username, code);
-        return ResponseEntity.ok(ApiResponse.success(result));
     }
 
     /**

--- a/back-end/src/main/java/com/emailrelay/dto/AuthToken.java
+++ b/back-end/src/main/java/com/emailrelay/dto/AuthToken.java
@@ -1,0 +1,4 @@
+package com.emailrelay.dto;
+
+public record AuthToken(String accessToken, String refreshToken) {
+}

--- a/back-end/src/main/java/com/emailrelay/security/TokenService.java
+++ b/back-end/src/main/java/com/emailrelay/security/TokenService.java
@@ -20,10 +20,10 @@ public class TokenService {
     @Value("${jwt.secret}")
     private String secret;
 
-    @Value("${jwt.access-token-expiration}")
+    @Value("${jwt.access-token.expiration}")
     private Long accessTokenExpiration;
 
-    @Value("${jwt.refresh-token-expiration}")
+    @Value("${jwt.refresh-token.expiration}")
     private Long refreshTokenExpiration;
 
     private SecretKey secretKey;

--- a/back-end/src/main/java/com/emailrelay/service/AuthService.java
+++ b/back-end/src/main/java/com/emailrelay/service/AuthService.java
@@ -1,6 +1,8 @@
 package com.emailrelay.service;
 
+import com.emailrelay.dto.AuthToken;
 import com.emailrelay.exception.CustomException;
+import com.emailrelay.security.TokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,6 +18,7 @@ public class AuthService {
 
     private final CacheService cacheService;
     private final SendEmailService sendEmailService;
+    private final TokenService tokenService;
     private final SecureRandom secureRandom = new SecureRandom();
 
     @Value("${verification.code.expiration}")
@@ -24,9 +27,10 @@ public class AuthService {
     @Value("${verification.code.max-attempts}")
     private Integer maxAttempts;
 
-    private static final String CODE_PREFIX = "verification:code:";
-    private static final String ATTEMPT_PREFIX = "verification:attempt:";
+    private static final String CODE_PREFIX = "auth:verification:code:";
+    private static final String ATTEMPT_PREFIX = "auth:verification:attempt:";
     private static final String RATE_LIMIT_PREFIX = "verification:ratelimit:";
+    private static final String REFRESH_TOKEN_PREFIX = "auth:refresh:token:";
 
     public String sendVerificationCode(String email) {
         String code = generateCode();
@@ -69,6 +73,58 @@ public class AuthService {
 
         log.info("Verification successful for {}", email);
         return true;
+    }
+
+    public AuthToken generateTokens(Long userId, String username) {
+        try {
+            String accessToken = tokenService.generateAccessToken(userId, username);
+            String refreshToken = tokenService.generateRefreshToken(userId, username);
+            return new AuthToken(accessToken, refreshToken);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to grant auth tokens");
+        }
+    }
+
+    public Long getAccessTokenTTL() {
+        return tokenService.getAccessTokenExpiration();
+    }
+
+    public Long getRefreshTokenTTL() {
+        return tokenService.getRefreshTokenExpiration();
+    }
+
+    public boolean validateToken(String token) {
+        return tokenService.validateToken(token);
+    }
+
+    public Long getUserIdFromToken(String token) {
+        return tokenService.getUserIdFromToken(token);
+    }
+
+    public String getUsernameFromToken(String token) {
+        return tokenService.getUsernameFromToken(token);
+    }
+
+    public String generateAccessToken(Long userId, String username) {
+        return tokenService.generateAccessToken(userId, username);
+    }
+
+    public void storeRefreshToken(Long userId, String refreshToken) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        cacheService.setRaw(key, refreshToken, getRefreshTokenTTL(), TimeUnit.MILLISECONDS);
+        log.info("Stored refresh token for user: {}", userId);
+    }
+
+    public boolean validateRefreshTokenInCache(Long userId, String refreshToken) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        String storedToken = (String) cacheService.getRaw(key);
+        return storedToken != null && storedToken.equals(refreshToken);
+    }
+
+    public void removeRefreshToken(Long userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        cacheService.deleteRaw(key);
+        log.info("Removed refresh token for user: {}", userId);
     }
 
     private String generateCode() {

--- a/back-end/src/main/java/com/emailrelay/service/UserService.java
+++ b/back-end/src/main/java/com/emailrelay/service/UserService.java
@@ -1,11 +1,13 @@
 package com.emailrelay.service;
 
+import com.emailrelay.dto.AuthToken;
 import com.emailrelay.exception.CustomException.*;
 import com.emailrelay.model.User;
 import com.emailrelay.repository.UserRepository;
 import com.emailrelay.security.TokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -66,9 +68,13 @@ public class UserService {
     }
 
     @Transactional
-    public String login(String username) {
+    public AuthToken login(String username) {
         Long userId = userRepository.findByUsername(username).get().getId();
-        return tokenService.generateAccessToken(userId, username);
+        AuthToken authToken = authService.generateTokens(userId, username);
+
+        // Store refresh token in Redis
+        authService.storeRefreshToken(userId, authToken.refreshToken());
+        return authToken;
     }
 
     @Transactional

--- a/front-end/src/lib/api.ts
+++ b/front-end/src/lib/api.ts
@@ -10,11 +10,135 @@ interface ApiResponse<T> {
 }
 
 /**
+ * In-memory access token storage
+ * This will be cleared when the tab is closed or page is refreshed
+ */
+let accessToken: string | null = null;
+
+/**
+ * Set the access token in memory
+ */
+export function setAccessToken(token: string | null): void {
+  accessToken = token;
+}
+
+/**
+ * Get the current access token from memory
+ */
+export function getAccessToken(): string | null {
+  return accessToken;
+}
+
+/**
+ * Decode JWT token to get payload
+ */
+function decodeJWT(token: string): any {
+  try {
+    const base64Url = token.split('.')[1];
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split('')
+        .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join('')
+    );
+    return JSON.parse(jsonPayload);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get username from access token
+ */
+export function getUsernameFromToken(): string | null {
+  if (!accessToken) return null;
+  const payload = decodeJWT(accessToken);
+  return payload?.username || null;
+}
+
+/**
+ * Clear the access token from memory
+ */
+export function clearAccessToken(): void {
+  accessToken = null;
+}
+
+/**
+ * Refresh the access token using the refresh token from HTTP-only cookie
+ * @returns New access token
+ */
+export async function refreshToken(): Promise<string> {
+  const response = await fetch(`${API_BASE_URL}/api/auth/refresh`, {
+    method: 'POST',
+    credentials: 'include', // Include HTTP-only cookies
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  const apiResponse: ApiResponse<string> = await response.json();
+
+  if (!response.ok || apiResponse.result === 'fail') {
+    throw new Error(
+      typeof apiResponse.data === 'string'
+        ? apiResponse.data
+        : 'Failed to refresh token'
+    );
+  }
+
+  const newAccessToken = apiResponse.data;
+  setAccessToken(newAccessToken);
+  return newAccessToken;
+}
+
+/**
+ * Make an authenticated API request with automatic token refresh
+ */
+async function authenticatedFetch(
+  url: string,
+  options: RequestInit = {}
+): Promise<Response> {
+  // Add authorization header if access token exists
+  const headers = new Headers(options.headers);
+  if (accessToken) {
+    headers.set('Authorization', `Bearer ${accessToken}`);
+  }
+
+  let response = await fetch(url, {
+    ...options,
+    headers,
+    credentials: 'include', // Include HTTP-only cookies
+  });
+
+  // If unauthorized and we haven't tried to refresh yet, try refreshing the token
+  if (response.status === 401) {
+    try {
+      await refreshToken();
+
+      // Retry the request with the new token
+      headers.set('Authorization', `Bearer ${accessToken}`);
+      response = await fetch(url, {
+        ...options,
+        headers,
+        credentials: 'include',
+      });
+    } catch (error) {
+      // Refresh failed, clear token and propagate error
+      clearAccessToken();
+      throw error;
+    }
+  }
+
+  return response;
+}
+
+/**
  * Send verification code to the user's email
  * @param email - User's email address
  */
 export async function sendVerificationCode(email: string): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}/api/users/send-verification-code?username=${encodeURIComponent(email)}`, {
+  const response = await fetch(`${API_BASE_URL}/api/auth/send-verification-code?username=${encodeURIComponent(email)}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -33,28 +157,78 @@ export async function sendVerificationCode(email: string): Promise<void> {
 }
 
 /**
- * Verify the code entered by the user
+ * Login with verification code
  * @param email - User's email address
  * @param code - Verification code
- * @returns true if verification is successful, false otherwise
+ * @returns Access token
  */
-export async function verifyCode(email: string, code: string): Promise<boolean> {
-  const response = await fetch(`${API_BASE_URL}/api/users/verify-code?username=${encodeURIComponent(email)}&code=${encodeURIComponent(code)}`, {
+export async function login(email: string, code: string): Promise<string> {
+  const response = await fetch(`${API_BASE_URL}/api/auth/login?username=${encodeURIComponent(email)}&code=${encodeURIComponent(code)}`, {
     method: 'POST',
+    credentials: 'include', // Include cookies for refresh token
     headers: {
       'Content-Type': 'application/json',
     },
   });
 
-  const apiResponse: ApiResponse<boolean> = await response.json();
+  const apiResponse: ApiResponse<string> = await response.json();
 
   if (!response.ok || apiResponse.result === 'fail') {
     throw new Error(
       typeof apiResponse.data === 'string'
         ? apiResponse.data
-        : 'Failed to verify code'
+        : 'Failed to login'
     );
   }
 
-  return apiResponse.data;
+  // Store access token in memory
+  const token = apiResponse.data;
+  setAccessToken(token);
+  return token;
+}
+
+/**
+ * Logout and clear tokens
+ */
+export async function logout(): Promise<void> {
+  // Call backend logout endpoint to remove refresh token from Redis and cookie
+  try {
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+    };
+
+    // Include access token in Authorization header for authentication
+    if (accessToken) {
+      headers['Authorization'] = `Bearer ${accessToken}`;
+    }
+
+    await fetch(`${API_BASE_URL}/api/auth/logout`, {
+      method: 'POST',
+      credentials: 'include',
+      headers,
+    });
+  } catch (error) {
+    // Ignore errors during logout
+    console.error('Logout error:', error);
+  } finally {
+    // Always clear access token from memory
+    clearAccessToken();
+  }
+}
+
+/**
+ * Check if user is authenticated
+ * Tries to refresh token if access token is not available
+ */
+export async function checkAuth(): Promise<boolean> {
+  if (accessToken) {
+    return true;
+  }
+
+  try {
+    await refreshToken();
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
- Grant access token and refresh token when user logged in.
- Access token has 15 minutes as TTL, Refresh token has 7 days as TTL.
- Access token is managed by Client in the memory, Refresh token is managed by Server in the database (cache db)
- Use Spring SecurityContext as Session management.
- Refactor authentication api endpoints between server and client
- When access token lost or expired, refresh token.
- When loggout, remove session from the database and clear context holder.