### PR TITLE
Feat. improve readability of relay and reply email addresses with hyphen formatting

### DIFF
--- a/back-end/src/common/utils/relay-email.util.ts
+++ b/back-end/src/common/utils/relay-email.util.ts
@@ -18,21 +18,36 @@ export function isValidRelayUsername(username: string): boolean {
 }
 
 /**
- * Generate a random relay email username
- * Generates a random alphanumeric string that complies with RELAY_USERNAME_PATTERN
- * @param length - The length of the username (default: 16)
- * @returns A random username string
+ * Format a string into hyphen-separated groups for readability
+ * e.g. "abcdefghij" with groupSize=5 → "abcde-fghij"
+ * @param str - The string to format
+ * @param groupSize - Number of characters per group (default: 5)
+ * @returns Hyphen-separated string
  */
-export function generateRandomRelayUsername(length: number = 16): string {
-  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
-  const bytes = randomBytes(length);
+export function formatWithHyphens(str: string, groupSize: number = 5): string {
+  const groups: string[] = [];
+  for (let i = 0; i < str.length; i += groupSize) {
+    groups.push(str.slice(i, i + groupSize));
+  }
+  return groups.join('-');
+}
 
-  let result = '';
-  for (let i = 0; i < length; i++) {
-    result += chars[bytes[i] % chars.length];
+/**
+ * Generate a random relay email username in readable hyphen-separated format
+ * Generates 15 random alphanumeric characters formatted as xxxxx-xxxxx-xxxxx
+ * @returns A random username string (e.g. "i505z-fmife-0gq77")
+ */
+export function generateRandomRelayUsername(): string {
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const totalLength = 15; // 3 groups of 5
+  const bytes = randomBytes(totalLength);
+
+  let raw = '';
+  for (let i = 0; i < totalLength; i++) {
+    raw += chars[bytes[i] % chars.length];
   }
 
-  return result;
+  return formatWithHyphens(raw);
 }
 
 /**

--- a/back-end/src/relay-emails/relay-emails.service.ts
+++ b/back-end/src/relay-emails/relay-emails.service.ts
@@ -54,7 +54,7 @@ export class RelayEmailsService {
     let exists = true;
 
     while (exists) {
-      const randomUsername = generateRandomRelayUsername(16);
+      const randomUsername = generateRandomRelayUsername();
       relayEmail = `${randomUsername}@${this.customEnvService.get<string>('APP_DOMAIN')}`;
 
       // Check if this relay address already exists

--- a/back-end/src/relay-emails/reply-emails.service.ts
+++ b/back-end/src/relay-emails/reply-emails.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { ReplyMasking } from './entities/reply-masking.entity';
 import { ProtectionUtil } from 'src/common/utils/protection.util';
 import { CustomEnvService } from 'src/config/custom-env.service';
+import { formatWithHyphens } from 'src/common/utils/relay-email.util';
 
 @Injectable()
 export class ReplyEmailsService {
@@ -45,6 +46,8 @@ export class ReplyEmailsService {
 
   private generateReplyMaskingEmail(sender: string, receiver: string): string {
     const domain = this.customEnvService.get<string>('APP_DOMAIN') || 'private-mailhub.com';
-    return 'reply-'.concat(this.protectionUtil.hash(`${sender}:${receiver}`)).concat(`@${domain}`);
+    const hash = this.protectionUtil.hash(`${sender}:${receiver}`);
+    const formattedHash = formatWithHyphens(hash.slice(0, 15));
+    return `reply-${formattedHash}@${domain}`;
   }
 }


### PR DESCRIPTION
## Summary

- Generate relay email usernames as `xxxxx-xxxxx-xxxxx` (3 groups of 5 alphanumeric chars) instead of a flat 16-char string (e.g. `i505z-fmife-0gq77@private-mailhub.com`)
- Generate reply masking addresses as `reply-xxxxx-xxxxx-xxxxx@domain` by taking the first 15 hex chars of the SHA-256 hash and splitting into hyphen-separated groups
- Extract a shared `formatWithHyphens()` utility in `relay-email.util.ts` used by both formatters

## Test plan

- [ ] Create a new relay email and verify the address follows the `xxxxx-xxxxx-xxxxx@domain` format
- [ ] Trigger an email forward and verify the reply-to address follows the `reply-xxxxx-xxxxx-xxxxx@domain` format
- [ ] Confirm replies sent to the masked reply address are correctly routed to the original sender
- [ ] Confirm existing custom relay email addresses (user-defined usernames) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)