### PR TITLE
Fix admin forward count windows using forward event history

### DIFF
--- a/back-end/src/admin/admin.module.ts
+++ b/back-end/src/admin/admin.module.ts
@@ -4,10 +4,11 @@ import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
 import { User } from '../users/entities/user.entity';
 import { RelayEmail } from '../relay-emails/entities/relay-email.entity';
+import { ForwardEvent } from '../relay-emails/entities/forward-event.entity';
 import { UsersModule } from '../users/users.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, RelayEmail]), UsersModule],
+  imports: [TypeOrmModule.forFeature([User, RelayEmail, ForwardEvent]), UsersModule],
   controllers: [AdminController],
   providers: [AdminService],
 })

--- a/back-end/src/admin/admin.service.ts
+++ b/back-end/src/admin/admin.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { MoreThanOrEqual, Repository } from 'typeorm';
 import { User } from '../users/entities/user.entity';
 import { RelayEmail } from '../relay-emails/entities/relay-email.entity';
+import { ForwardEvent } from '../relay-emails/entities/forward-event.entity';
 
 @Injectable()
 export class AdminService {
@@ -11,6 +12,8 @@ export class AdminService {
     private userRepository: Repository<User>,
     @InjectRepository(RelayEmail)
     private relayEmailRepository: Repository<RelayEmail>,
+    @InjectRepository(ForwardEvent)
+    private forwardEventRepository: Repository<ForwardEvent>,
   ) {}
 
   async getDashboardStats() {
@@ -43,23 +46,13 @@ export class AdminService {
       this.relayEmailRepository.count({
         where: { createdAt: MoreThanOrEqual(days7Ago) },
       }),
-      this.relayEmailRepository
-        .createQueryBuilder('re')
-        .select('COALESCE(SUM(re.forward_count), 0)', 'total')
-        .getRawOne()
-        .then((result) => Number(result.total)),
-      this.relayEmailRepository
-        .createQueryBuilder('re')
-        .select('COALESCE(SUM(re.forward_count), 0)', 'total')
-        .where('re.last_forwarded_at >= :date', { date: days28Ago })
-        .getRawOne()
-        .then((result) => Number(result.total)),
-      this.relayEmailRepository
-        .createQueryBuilder('re')
-        .select('COALESCE(SUM(re.forward_count), 0)', 'total')
-        .where('re.last_forwarded_at >= :date', { date: days7Ago })
-        .getRawOne()
-        .then((result) => Number(result.total)),
+      this.forwardEventRepository.count(),
+      this.forwardEventRepository.count({
+        where: { createdAt: MoreThanOrEqual(days28Ago) },
+      }),
+      this.forwardEventRepository.count({
+        where: { createdAt: MoreThanOrEqual(days7Ago) },
+      }),
     ]);
 
     return {

--- a/back-end/src/app.module.ts
+++ b/back-end/src/app.module.ts
@@ -13,6 +13,7 @@ import { AdminModule } from './admin/admin.module';
 import { User } from './users/entities/user.entity';
 import { RelayEmail } from './relay-emails/entities/relay-email.entity';
 import { ReplyMasking } from './relay-emails/entities/reply-masking.entity';
+import { ForwardEvent } from './relay-emails/entities/forward-event.entity';
 import { AuthGuard } from './common/guards/auth.guard';
 
 @Module({
@@ -28,7 +29,7 @@ import { AuthGuard } from './common/guards/auth.guard';
       database: process.env.DATABASE_NAME,
       username: process.env.DATABASE_USERNAME,
       password: process.env.DATABASE_PASSWORD,
-      entities: [User, RelayEmail, ReplyMasking],
+      entities: [User, RelayEmail, ReplyMasking, ForwardEvent],
       synchronize: false,
       logging: process.env.NODE_ENV === 'production',
     }),

--- a/back-end/src/data-source.ts
+++ b/back-end/src/data-source.ts
@@ -3,6 +3,7 @@ import * as dotenv from 'dotenv';
 import { User } from './users/entities/user.entity';
 import { RelayEmail } from './relay-emails/entities/relay-email.entity';
 import { ReplyMasking } from './relay-emails/entities/reply-masking.entity';
+import { ForwardEvent } from './relay-emails/entities/forward-event.entity';
 
 dotenv.config();
 
@@ -13,7 +14,7 @@ export const AppDataSource = new DataSource({
   database: process.env.DATABASE_NAME,
   username: process.env.DATABASE_USERNAME,
   password: process.env.DATABASE_PASSWORD,
-  entities: [User, RelayEmail, ReplyMasking],
+  entities: [User, RelayEmail, ReplyMasking, ForwardEvent],
   migrations: ['src/migrations/*.ts'],
   synchronize: false,
   logging: process.env.NODE_ENV !== 'production',

--- a/back-end/src/migrations/1771700000000-AddForwardEventsTable.ts
+++ b/back-end/src/migrations/1771700000000-AddForwardEventsTable.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddForwardEventsTable1771700000000 implements MigrationInterface {
+  name = 'AddForwardEventsTable1771700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE \`forward_events\` (
+        \`id\` bigint NOT NULL AUTO_INCREMENT,
+        \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        \`relay_email_id\` bigint NOT NULL,
+        INDEX \`idx_forward_events_relay_email_id\` (\`relay_email_id\`),
+        INDEX \`idx_forward_events_created_at\` (\`created_at\`),
+        PRIMARY KEY (\`id\`)
+      ) ENGINE=InnoDB
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE \`forward_events\`
+      ADD CONSTRAINT \`FK_forward_events_relay_email\`
+      FOREIGN KEY (\`relay_email_id\`) REFERENCES \`relay_emails\`(\`id\`)
+      ON DELETE CASCADE ON UPDATE NO ACTION
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `forward_events` DROP FOREIGN KEY `FK_forward_events_relay_email`',
+    );
+    await queryRunner.query('DROP TABLE `forward_events`');
+  }
+}

--- a/back-end/src/relay-emails/entities/forward-event.entity.ts
+++ b/back-end/src/relay-emails/entities/forward-event.entity.ts
@@ -1,0 +1,23 @@
+import {
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { RelayEmail } from './relay-email.entity';
+
+@Entity('forward_events')
+export class ForwardEvent {
+  @PrimaryGeneratedColumn({ type: 'bigint' })
+  id: bigint;
+
+  @Index('idx_forward_events_relay_email_id')
+  @ManyToOne(() => RelayEmail, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'relay_email_id' })
+  relayEmail: RelayEmail;
+
+  @CreateDateColumn({ name: 'created_at', type: 'datetime' })
+  createdAt: Date;
+}

--- a/back-end/src/relay-emails/relay-emails.module.ts
+++ b/back-end/src/relay-emails/relay-emails.module.ts
@@ -4,6 +4,7 @@ import { RelayEmailsController } from './relay-emails.controller';
 import { RelayEmailsService } from './relay-emails.service';
 import { RelayEmail } from './entities/relay-email.entity';
 import { ReplyMasking } from './entities/reply-masking.entity';
+import { ForwardEvent } from './entities/forward-event.entity';
 import { CacheModule } from '../cache/cache.module';
 import { UsersModule } from '../users/users.module';
 import { AwsModule } from '../aws/aws.module';
@@ -15,7 +16,7 @@ import { ReplyEmailsService } from './reply-emails.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([RelayEmail, ReplyMasking]),
+    TypeOrmModule.forFeature([RelayEmail, ReplyMasking, ForwardEvent]),
     CacheModule,
     UsersModule,
     AwsModule,

--- a/back-end/src/relay-emails/relay-emails.service.ts
+++ b/back-end/src/relay-emails/relay-emails.service.ts
@@ -21,6 +21,7 @@ import { generateRandomRelayUsername } from 'src/common/utils/relay-email.util';
 import { User } from 'src/users/entities/user.entity';
 import { isProTier } from 'src/common/utils/permission.util';
 import { ReplyEmailsService } from './reply-emails.service';
+import { ForwardEvent } from './entities/forward-event.entity';
 
 @Injectable()
 export class RelayEmailsService {
@@ -555,15 +556,32 @@ export class RelayEmailsService {
   }
 
   async incrementForwardCount(relayEmail: string): Promise<void> {
-    await this.relayEmailRepository
-      .createQueryBuilder()
-      .update(RelayEmail)
-      .set({
-        forwardCount: () => 'forward_count + 1',
-        lastForwardedAt: new Date(),
-      })
-      .where('relay_email = :relayEmail', { relayEmail })
-      .execute();
+    const relayEmailEntity = await this.relayEmailRepository.findOne({
+      where: { relayEmail },
+      select: ['id'],
+    });
+
+    if (!relayEmailEntity) {
+      return;
+    }
+
+    await this.relayEmailRepository.manager.transaction(async (manager) => {
+      await manager
+        .createQueryBuilder()
+        .update(RelayEmail)
+        .set({
+          forwardCount: () => 'forward_count + 1',
+          lastForwardedAt: new Date(),
+        })
+        .where('id = :id', { id: relayEmailEntity.id })
+        .execute();
+
+      const forwardEvent = manager.create(ForwardEvent, {
+        relayEmail: relayEmailEntity,
+      });
+
+      await manager.save(forwardEvent);
+    });
   }
 
   async countByUser(userId: bigint): Promise<number> {

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -53,5 +53,15 @@ CREATE TABLE IF NOT EXISTS reply_maskings (
   INDEX idx_sender_receiver_hash (sender_address_hash, receiver_address_hash)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- Forward Events table
+CREATE TABLE IF NOT EXISTS forward_events (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  relay_email_id BIGINT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  INDEX idx_forward_events_relay_email_id (relay_email_id),
+  INDEX idx_forward_events_created_at (created_at),
+  FOREIGN KEY (relay_email_id) REFERENCES relay_emails(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 -- Verify tables
 SHOW TABLES;


### PR DESCRIPTION
### Motivation
- The admin dashboard was summing `relay_emails.forward_count` filtered by `last_forwarded_at`, which produces incorrect windowed counts because it aggregates cumulative per-address totals instead of individual forward events. 
- We need accurate per-window metrics (total, last 28 days, last 7 days) and transactional consistency between the cumulative counter and windowed history.

### Description
- Add a new `ForwardEvent` entity and table (`forward_events`) to record one row per successful forward (`back-end/src/relay-emails/entities/forward-event.entity.ts` and migration `back-end/src/migrations/1771700000000-AddForwardEventsTable.ts`).
- Update the forward processing in `incrementForwardCount` to run inside a transaction that updates `relay_emails.forward_count`, sets `last_forwarded_at`, and inserts a `forward_events` row atomically (`back-end/src/relay-emails/relay-emails.service.ts`).
- Change admin stats to compute forward totals and windows from `forward_events.created_at` (use `forwardEventRepository.count()` for `total`, `last28Days`, `last7Days`) instead of summing `relay_emails.forward_count` (`back-end/src/admin/admin.service.ts`).
- Register the new entity across the app and migrations by updating `TypeORM` entity lists and `init-db.sql` to include `forward_events` (`back-end/src/app.module.ts`, `back-end/src/data-source.ts`, `back-end/src/relay-emails/relay-emails.module.ts`, `back-end/src/admin/admin.module.ts`, and `scripts/init-db.sql`).

### Testing
- Ran `npm run build` in `back-end` after changes and the build completed successfully with no errors (ESLint/prettier ran and reported 5 pre-existing `no-explicit-any` warnings). 
- Verified the new migration file is present and entity registrations compile cleanly with the updated `AppDataSource` and `TypeORM` configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5da3a3ee88329ad59a939811b5d99)