### PR TITLE
Refactor. try catch block captured mailgun api service

### DIFF
--- a/back-end/src/relay-emails/relay-emails.service.ts
+++ b/back-end/src/relay-emails/relay-emails.service.ts
@@ -418,16 +418,21 @@ export class RelayEmailsService {
         attachments: attachments.length > 0 ? attachments : undefined,
       });
 
-      // Increment forward count
-      await this.incrementForwardCount(relayEmailAddress);
+      // Increment forward count (non-critical, failure is only logged)
+      try {
+        await this.incrementForwardCount(relayEmailAddress);
+      } catch (err) {
+        this.logger.error(
+          `Failed to increment forward count for ${this.maskEmail(relayEmailAddress)}: ${(err as Error).message}`,
+        );
+      }
     } catch (error) {
       const fromAddress = mail?.from?.text ?? 'unknown';
       this.logger.error(
         `Failed to forward email to ${this.maskEmail(primaryEmailAddress)} from ${this.maskEmail(fromAddress)}, error=${(error as Error).message}`,
         (error as Error).stack,
       );
-
-      return;
+      throw error;
     }
   }
 
@@ -462,6 +467,15 @@ export class RelayEmailsService {
         attachments: attachments.length > 0 ? attachments : undefined,
       });
 
+      // Increment forward count (non-critical, failure is only logged)
+      try {
+        await this.incrementForwardCount(relayAddress);
+      } catch (err) {
+        this.logger.error(
+          `Failed to increment forward count for ${this.maskEmail(relayAddress)}: ${(err as Error).message}`,
+        );
+      }
+
       this.logger.log(
         `Reply relayed from ${this.maskEmail(relayAddress)} to ${this.maskEmail(originalSenderAddress)}`,
       );
@@ -470,6 +484,7 @@ export class RelayEmailsService {
         `Failed to relay reply to ${this.maskEmail(originalSenderAddress)} via ${this.maskEmail(relayAddress)}, error=${(error as Error).message}`,
         (error as Error).stack,
       );
+      throw error;
     }
   }
 

--- a/back-end/src/relay-emails/relay-emails.service.ts
+++ b/back-end/src/relay-emails/relay-emails.service.ts
@@ -337,10 +337,8 @@ export class RelayEmailsService {
           relayEmailAddress,
         );
         replyMaskEmail = res.replyAddress;
-      } catch (err) {
-        this.logger.error(
-          `failed to get reply mask email address when forward mail by ${err.message}`,
-        );
+      } catch (error) {
+        this.logger.error(`failed to get reply mask email address when forward mail `, error);
         replyMaskEmail = relayEmailAddress;
       }
 
@@ -421,17 +419,11 @@ export class RelayEmailsService {
       // Increment forward count (non-critical, failure is only logged)
       try {
         await this.incrementForwardCount(relayEmailAddress);
-      } catch (err) {
-        this.logger.error(
-          `Failed to increment forward count for ${this.maskEmail(relayEmailAddress)}: ${(err as Error).message}`,
-        );
+      } catch (error) {
+        this.logger.error(`Failed to increment forward count`, error);
       }
     } catch (error) {
-      const fromAddress = mail?.from?.text ?? 'unknown';
-      this.logger.error(
-        `Failed to forward email to ${this.maskEmail(primaryEmailAddress)} from ${this.maskEmail(fromAddress)}, error=${(error as Error).message}`,
-        (error as Error).stack,
-      );
+      this.logger.error(`Failed to forward email, `, error);
       throw error;
     }
   }
@@ -467,31 +459,17 @@ export class RelayEmailsService {
         attachments: attachments.length > 0 ? attachments : undefined,
       });
 
-      // Increment forward count (non-critical, failure is only logged)
       try {
         await this.incrementForwardCount(relayAddress);
-      } catch (err) {
-        this.logger.error(
-          `Failed to increment forward count for ${this.maskEmail(relayAddress)}: ${(err as Error).message}`,
-        );
+      } catch (error) {
+        this.logger.error(`Failed to increment forward count`, error);
       }
 
-      this.logger.log(
-        `Reply relayed from ${this.maskEmail(relayAddress)} to ${this.maskEmail(originalSenderAddress)}`,
-      );
+      this.logger.log(`Reply relayed successfully`);
     } catch (error) {
-      this.logger.error(
-        `Failed to relay reply to ${this.maskEmail(originalSenderAddress)} via ${this.maskEmail(relayAddress)}, error=${(error as Error).message}`,
-        (error as Error).stack,
-      );
+      this.logger.error(`Failed to relay reply`, error);
       throw error;
     }
-  }
-
-  private maskEmail(email: string): string {
-    const atIndex = email.indexOf('@');
-    if (atIndex <= 1) return '***';
-    return email[0] + '*'.repeat(Math.min(atIndex - 1, 5)) + email.substring(atIndex);
   }
 
   /**


### PR DESCRIPTION
When an error occurs, mailgun api removes mail that has not yet been sent from SQS, mistaking that the service has not made an exception and has processed the message differently than intended.

Errors in the Mailgun API are very important risks to the service, so they can be recognized by the service by throwing errors.