### PR TITLE
Format email address and limit length to 30 chars

### DIFF
--- a/back-end/src/common/utils/relay-email.util.ts
+++ b/back-end/src/common/utils/relay-email.util.ts
@@ -18,21 +18,26 @@ export function isValidRelayUsername(username: string): boolean {
 }
 
 /**
- * Generate a random relay email username
- * Generates a random alphanumeric string that complies with RELAY_USERNAME_PATTERN
- * @param length - The length of the username (default: 16)
- * @returns A random username string
+ * Generate random relay email username
+ * Generates a 10-character alphanumeric string with a hyphen after the 4th character.
+ * e.g. xx12-xxx34
+ * @returns A random username
  */
-export function generateRandomRelayUsername(length: number = 16): string {
+export function generateRelayUsername(): string {
   const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
-  const bytes = randomBytes(length);
+  const bytes = randomBytes(9);
 
-  let result = '';
-  for (let i = 0; i < length; i++) {
-    result += chars[bytes[i] % chars.length];
+  let pre = '';
+  let post = '';
+
+  for (let i = 0; i < 4; i++) {
+    pre += chars[bytes[i] % chars.length];
+  }
+  for (let i = 4; i < 9; i++) {
+    post += chars[bytes[i] % chars.length];
   }
 
-  return result;
+  return `${pre}-${post}`;
 }
 
 /**

--- a/back-end/src/relay-emails/relay-emails.service.ts
+++ b/back-end/src/relay-emails/relay-emails.service.ts
@@ -17,7 +17,7 @@ import { S3EventRecord, SqsService } from 'src/aws/sqs/sqs.service';
 import { SendMailService } from 'src/mail/send-mail.service';
 import { CustomEnvService } from 'src/config/custom-env.service';
 import { ProtectionUtil } from 'src/common/utils/protection.util';
-import { generateRandomRelayUsername } from 'src/common/utils/relay-email.util';
+import { generateRelayUsername } from 'src/common/utils/relay-email.util';
 import { User } from 'src/users/entities/user.entity';
 import { isProTier } from 'src/common/utils/permission.util';
 import { ReplyEmailsService } from './reply-emails.service';
@@ -54,8 +54,8 @@ export class RelayEmailsService {
     let exists = true;
 
     while (exists) {
-      const randomUsername = generateRandomRelayUsername(16);
-      relayEmail = `${randomUsername}@${this.customEnvService.get<string>('APP_DOMAIN')}`;
+      const username = generateRelayUsername();
+      relayEmail = `${username}@${this.customEnvService.get<string>('APP_DOMAIN')}`;
 
       // Check if this relay address already exists
       const existing = await this.relayEmailRepository.findOne({

--- a/back-end/test/common/utils/relay-email.util.spec.ts
+++ b/back-end/test/common/utils/relay-email.util.spec.ts
@@ -1,0 +1,34 @@
+import { generateRelayUsername } from 'src/common/utils/relay-email.util';
+
+describe('relay-email.util', () => {
+  describe('generateRelayUsername', () => {
+    describe('Given repeated invocations', () => {
+      it('When called, Then always returns a 10-character string', () => {
+        for (let i = 0; i < 100; i++) {
+          const username = generateRelayUsername();
+          const fullEmailAddress = username.concat('@private-mailhub.com');
+          expect(username).toHaveLength(10);
+          expect(fullEmailAddress).toHaveLength(30);
+        }
+      });
+
+      it('When called, Then matches the pattern of 4-char and 5-char alphanumeric segments joined by "-"', () => {
+        const pattern = /^[a-z0-9]{4}-[a-z0-9]{5}$/;
+        for (let i = 0; i < 100; i++) {
+          const username = generateRelayUsername();
+          expect(username).toMatch(pattern);
+        }
+      });
+
+      it('When called many times, Then the produced characters include both lowercase letters and digits', () => {
+        let combined = '';
+        for (let i = 0; i < 100; i++) {
+          combined += generateRelayUsername().replace('-', '');
+        }
+
+        expect(combined).toMatch(/[a-z]/);
+        expect(combined).toMatch(/[0-9]/);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# AS-IS
- email address length is 36. (e.g. `xxx123yyy456zzz7@private-mailhub.com`)
- It could not submit to signup in some web sites that did not comply with the standard


# TO-BE
- This rule was in compliance with [RFC 2821(4.5.3.1)](https://datatracker.ietf.org/doc/html/rfc2821#section-4.5.3.1), but some websites that did not comply with the standard had to adjust the length because it was an address length that did not work. 
- Also a hyphen was added to the local-part to improve readability. (e.g. `xyx9-123ho@private-mailhub.com`)