### PR TITLE
Add OAuthAccount schema to fix oauth login bug

### DIFF
--- a/back-end/src/app.module.ts
+++ b/back-end/src/app.module.ts
@@ -12,6 +12,7 @@ import { AwsModule } from './aws/aws.module';
 import { AdminModule } from './admin/admin.module';
 import { LogsModule } from './logs/logs.module';
 import { User } from './users/entities/user.entity';
+import { OAuthAccount } from './users/entities/oauth-account.entity';
 import { RelayEmail } from './relay-emails/entities/relay-email.entity';
 import { ReplyMasking } from './relay-emails/entities/reply-masking.entity';
 import { UserActivityLog } from './logs/entities/user-activity-log.entity';
@@ -31,7 +32,7 @@ import { AuthGuard } from './common/guards/auth.guard';
       database: process.env.DATABASE_NAME,
       username: process.env.DATABASE_USERNAME,
       password: process.env.DATABASE_PASSWORD,
-      entities: [User, RelayEmail, ReplyMasking, UserActivityLog, EmailForwardingLog],
+      entities: [User, OAuthAccount, RelayEmail, ReplyMasking, UserActivityLog, EmailForwardingLog],
       synchronize: false,
       logging: process.env.NODE_ENV === 'production',
     }),

--- a/back-end/src/data-source.ts
+++ b/back-end/src/data-source.ts
@@ -1,6 +1,7 @@
 import { DataSource } from 'typeorm';
 import * as dotenv from 'dotenv';
 import { User } from './users/entities/user.entity';
+import { OAuthAccount } from './users/entities/oauth-account.entity';
 import { RelayEmail } from './relay-emails/entities/relay-email.entity';
 import { ReplyMasking } from './relay-emails/entities/reply-masking.entity';
 import { UserActivityLog } from './logs/entities/user-activity-log.entity';
@@ -15,7 +16,7 @@ export const AppDataSource = new DataSource({
   database: process.env.DATABASE_NAME,
   username: process.env.DATABASE_USERNAME,
   password: process.env.DATABASE_PASSWORD,
-  entities: [User, RelayEmail, ReplyMasking, UserActivityLog, EmailForwardingLog],
+  entities: [User, OAuthAccount, RelayEmail, ReplyMasking, UserActivityLog, EmailForwardingLog],
   migrations: ['src/migrations/*.ts'],
   synchronize: false,
   logging: process.env.NODE_ENV !== 'production',

--- a/back-end/src/migrations/1771000000000-AddUniqueIndexesForOAuthIds.ts
+++ b/back-end/src/migrations/1771000000000-AddUniqueIndexesForOAuthIds.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUniqueIndexesForOAuthIds1771000000000 implements MigrationInterface {
+  name = 'AddUniqueIndexesForOAuthIds1771000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`users\` ADD UNIQUE INDEX \`UQ_users_gh_oauth\` (\`gh_oauth\`)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`users\` ADD UNIQUE INDEX \`UQ_users_aapl_oauth\` (\`aapl_oauth\`)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`users\` ADD UNIQUE INDEX \`UQ_users_goog_oauth\` (\`goog_oauth\`)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`users\` DROP INDEX \`UQ_users_goog_oauth\``);
+    await queryRunner.query(`ALTER TABLE \`users\` DROP INDEX \`UQ_users_aapl_oauth\``);
+    await queryRunner.query(`ALTER TABLE \`users\` DROP INDEX \`UQ_users_gh_oauth\``);
+  }
+}

--- a/back-end/src/migrations/1771100000000-AddOAuthIdentities.ts
+++ b/back-end/src/migrations/1771100000000-AddOAuthIdentities.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOAuthIdentities1771100000000 implements MigrationInterface {
+  name = 'AddOAuthIdentities1771100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE \`oauth_accounts\` (
+        \`id\` bigint NOT NULL AUTO_INCREMENT,
+        \`user_id\` bigint NOT NULL,
+        \`provider\` varchar(50) NOT NULL,
+        \`oauth_id\` varchar(255) NOT NULL,
+        \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+        UNIQUE INDEX \`UQ_oauth_accounts_provider_oauth_id\` (\`provider\`, \`oauth_id\`),
+        UNIQUE INDEX \`UQ_oauth_accounts_user_id_provider\` (\`user_id\`, \`provider\`),
+        INDEX \`idx_oauth_accounts_user_id\` (\`user_id\`),
+        PRIMARY KEY (\`id\`),
+        CONSTRAINT \`FK_oauth_accounts_user_id\` FOREIGN KEY (\`user_id\`) REFERENCES \`users\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION
+      ) ENGINE=InnoDB
+    `);
+
+    await queryRunner.query(`
+      INSERT INTO \`oauth_accounts\` (\`user_id\`, \`provider\`, \`oauth_id\`)
+      SELECT \`id\`, 'github', \`gh_oauth\`
+      FROM \`users\`
+      WHERE \`gh_oauth\` IS NOT NULL
+    `);
+
+    await queryRunner.query(`
+      INSERT INTO \`oauth_accounts\` (\`user_id\`, \`provider\`, \`oauth_id\`)
+      SELECT \`id\`, 'apple', \`aapl_oauth\`
+      FROM \`users\`
+      WHERE \`aapl_oauth\` IS NOT NULL
+    `);
+
+    await queryRunner.query(`
+      INSERT INTO \`oauth_accounts\` (\`user_id\`, \`provider\`, \`oauth_id\`)
+      SELECT \`id\`, 'google', \`goog_oauth\`
+      FROM \`users\`
+      WHERE \`goog_oauth\` IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`oauth_accounts\` DROP FOREIGN KEY \`FK_oauth_accounts_user_id\``);
+    await queryRunner.query(`DROP INDEX \`idx_oauth_accounts_user_id\` ON \`oauth_accounts\``);
+    await queryRunner.query(`DROP INDEX \`UQ_oauth_accounts_user_id_provider\` ON \`oauth_accounts\``);
+    await queryRunner.query(`DROP INDEX \`UQ_oauth_accounts_provider_oauth_id\` ON \`oauth_accounts\``);
+    await queryRunner.query(`DROP TABLE \`oauth_accounts\``);
+  }
+}

--- a/back-end/src/users/entities/oauth-account.entity.ts
+++ b/back-end/src/users/entities/oauth-account.entity.ts
@@ -1,0 +1,38 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import { OAuthProvider } from '../../common/enums/oauth-provider.enum';
+
+@Entity('oauth_accounts')
+@Index('UQ_oauth_accounts_provider_oauth_id', ['provider', 'oauthId'], { unique: true })
+@Index('UQ_oauth_accounts_user_id_provider', ['userId', 'provider'], { unique: true })
+@Index('idx_oauth_accounts_user_id', ['userId'])
+export class OAuthAccount {
+  @PrimaryGeneratedColumn({ type: 'bigint' })
+  id: bigint;
+
+  @Column({
+    name: 'user_id',
+    type: 'bigint',
+  })
+  userId: bigint;
+
+  @Column({
+    type: 'varchar',
+    length: 50,
+    enum: OAuthProvider,
+    name: 'provider',
+  })
+  provider: OAuthProvider;
+
+  @Column({
+    name: 'oauth_id',
+    type: 'varchar',
+    length: 255,
+  })
+  oauthId: string;
+
+  @CreateDateColumn({ name: 'created_at', type: 'datetime' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'datetime' })
+  updatedAt: Date;
+}

--- a/back-end/src/users/entities/user.entity.ts
+++ b/back-end/src/users/entities/user.entity.ts
@@ -84,6 +84,7 @@ export class User {
     type: 'varchar',
     length: 255,
     nullable: true,
+    unique: true,
   })
   githubOAuth: string | null;
 
@@ -92,6 +93,7 @@ export class User {
     type: 'varchar',
     length: 255,
     nullable: true,
+    unique: true,
   })
   appleOAuth: string | null;
 
@@ -100,6 +102,7 @@ export class User {
     type: 'varchar',
     length: 255,
     nullable: true,
+    unique: true,
   })
   googleOAuth: string | null;
 

--- a/back-end/src/users/users.module.ts
+++ b/back-end/src/users/users.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { User } from './entities/user.entity';
+import { OAuthAccount } from './entities/oauth-account.entity';
 import { ProtectionUtil } from 'src/common/utils/protection.util';
 import { CacheModule } from '../cache/cache.module';
 import { AwsModule } from '../aws/aws.module';
@@ -10,7 +11,7 @@ import { MailModule } from 'src/mail/mail.module';
 import { LogsModule } from '../logs/logs.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), CacheModule, AwsModule, MailModule, LogsModule],
+  imports: [TypeOrmModule.forFeature([User, OAuthAccount]), CacheModule, AwsModule, MailModule, LogsModule],
   controllers: [UsersController],
   providers: [UsersService, ProtectionUtil],
   exports: [UsersService],

--- a/back-end/src/users/users.service.ts
+++ b/back-end/src/users/users.service.ts
@@ -27,7 +27,7 @@ export class UsersService {
     @InjectRepository(User)
     private userRepository: Repository<User>,
     @InjectRepository(OAuthAccount)
-    private oauthIdentityRepository: Repository<OAuthAccount>,
+    private oauthAccountRepository: Repository<OAuthAccount>,
     private proectionUtil: ProtectionUtil,
     private cacheService: CacheService,
     private sendMailService: SendMailService,
@@ -174,7 +174,7 @@ export class UsersService {
   };
 
   async findByOAuthId(provider: OAuthProvider, oauthId: string): Promise<User | null> {
-    const existingIdentity = await this.oauthIdentityRepository.findOne({
+    const existingIdentity = await this.oauthAccountRepository.findOne({
       where: { provider, oauthId },
     });
     if (existingIdentity) {
@@ -261,7 +261,7 @@ export class UsersService {
         ...(tokenField ? { [tokenField]: null } : {}),
       },
     );
-    await this.oauthIdentityRepository.delete({ userId, provider });
+    await this.oauthAccountRepository.delete({ userId, provider });
 
     await this.userActivityLogService.record(userId, UserActivityType.OAUTH_UNLINK, provider);
   }
@@ -351,7 +351,7 @@ export class UsersService {
     provider: OAuthProvider,
     oauthId: string,
   ): Promise<void> {
-    const existingIdentity = await this.oauthIdentityRepository.findOne({
+    const existingIdentity = await this.oauthAccountRepository.findOne({
       where: { provider, oauthId },
     });
 
@@ -362,18 +362,18 @@ export class UsersService {
       return;
     }
 
-    const staleIdentity = await this.oauthIdentityRepository.findOne({
+    const staleIdentity = await this.oauthAccountRepository.findOne({
       where: { userId, provider },
     });
     if (staleIdentity) {
-      await this.oauthIdentityRepository.remove(staleIdentity);
+      await this.oauthAccountRepository.remove(staleIdentity);
     }
 
-    const identity = this.oauthIdentityRepository.create({
+    const identity = this.oauthAccountRepository.create({
       userId,
       provider,
       oauthId,
     });
-    await this.oauthIdentityRepository.save(identity);
+    await this.oauthAccountRepository.save(identity);
   }
 }

--- a/back-end/src/users/users.service.ts
+++ b/back-end/src/users/users.service.ts
@@ -9,6 +9,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Not, Repository } from 'typeorm';
 import { User } from './entities/user.entity';
+import { OAuthAccount } from './entities/oauth-account.entity';
 import { SubscriptionTier } from '../common/enums/subscription-tier.enum';
 import { OAuthProvider } from '../common/enums/oauth-provider.enum';
 import { ProtectionUtil } from 'src/common/utils/protection.util';
@@ -25,6 +26,8 @@ export class UsersService {
   constructor(
     @InjectRepository(User)
     private userRepository: Repository<User>,
+    @InjectRepository(OAuthAccount)
+    private oauthIdentityRepository: Repository<OAuthAccount>,
     private proectionUtil: ProtectionUtil,
     private cacheService: CacheService,
     private sendMailService: SendMailService,
@@ -171,10 +174,23 @@ export class UsersService {
   };
 
   async findByOAuthId(provider: OAuthProvider, oauthId: string): Promise<User | null> {
+    const existingIdentity = await this.oauthIdentityRepository.findOne({
+      where: { provider, oauthId },
+    });
+    if (existingIdentity) {
+      return await this.findById(existingIdentity.userId);
+    }
+
     const field = UsersService.OAUTH_FIELD_MAP[provider];
-    return await this.userRepository.findOne({
+    const user = await this.userRepository.findOne({
       where: { [field]: oauthId },
     });
+    if (!user) {
+      return null;
+    }
+
+    await this.ensureOAuthIdentity(user.id, provider, oauthId);
+    return user;
   }
 
   async createOAuthUser(
@@ -201,7 +217,10 @@ export class UsersService {
         ...(tokenField && encryptedToken ? { [tokenField]: encryptedToken } : {}),
       });
 
-      return await this.userRepository.save(user);
+      const savedUser = await this.userRepository.save(user);
+      await this.ensureOAuthIdentity(savedUser.id, provider, oauthId);
+
+      return savedUser;
     } catch (err) {
       if (err instanceof ConflictException) throw err;
       this.logger.error(err, 'Failed to create OAuth user');
@@ -225,6 +244,7 @@ export class UsersService {
         ...(tokenField && encryptedToken ? { [tokenField]: encryptedToken } : {}),
       },
     );
+    await this.ensureOAuthIdentity(userId, provider, oauthId);
 
     if (options.recordActivity ?? true) {
       await this.userActivityLogService.record(userId, UserActivityType.OAUTH_LINK, provider);
@@ -241,6 +261,7 @@ export class UsersService {
         ...(tokenField ? { [tokenField]: null } : {}),
       },
     );
+    await this.oauthIdentityRepository.delete({ userId, provider });
 
     await this.userActivityLogService.record(userId, UserActivityType.OAUTH_UNLINK, provider);
   }
@@ -323,5 +344,36 @@ export class UsersService {
     await this.cacheService.deleteUsernameChangeData(userId);
 
     await this.userActivityLogService.record(userId, UserActivityType.USERNAME_CHANGE);
+  }
+
+  private async ensureOAuthIdentity(
+    userId: bigint,
+    provider: OAuthProvider,
+    oauthId: string,
+  ): Promise<void> {
+    const existingIdentity = await this.oauthIdentityRepository.findOne({
+      where: { provider, oauthId },
+    });
+
+    if (existingIdentity) {
+      if (existingIdentity.userId !== userId) {
+        throw new ConflictException('OAuth account is already linked to another user');
+      }
+      return;
+    }
+
+    const staleIdentity = await this.oauthIdentityRepository.findOne({
+      where: { userId, provider },
+    });
+    if (staleIdentity) {
+      await this.oauthIdentityRepository.remove(staleIdentity);
+    }
+
+    const identity = this.oauthIdentityRepository.create({
+      userId,
+      provider,
+      oauthId,
+    });
+    await this.oauthIdentityRepository.save(identity);
   }
 }

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -20,6 +20,20 @@ CREATE TABLE IF NOT EXISTS users (
   INDEX idx_username (username_hash)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- OAuth accounts table
+CREATE TABLE IF NOT EXISTS oauth_accounts (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  user_id BIGINT NOT NULL,
+  provider VARCHAR(50) NOT NULL,
+  oauth_id VARCHAR(255) NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_oauth_accounts_provider_oauth_id (provider, oauth_id),
+  UNIQUE KEY uq_oauth_accounts_user_id_provider (user_id, provider),
+  INDEX idx_oauth_accounts_user_id (user_id),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 -- Relay Emails table
 CREATE TABLE IF NOT EXISTS relay_emails (
   id BIGINT PRIMARY KEY AUTO_INCREMENT,


### PR DESCRIPTION
Issue: https://github.com/youngjinmo/mailhub/issues/39


  The root cause was that OAuth-linked accounts were matched using the provider email
  address, which can change over time. As a result, users whose provider email changed could
  be treated as new users and sent to the registration flow instead of logging into their
  existing account.

  ## AS-IS
  - OAuth accounts are identified by provider email.
  - If the provider email changes, the existing linked account cannot be found.
  - The user is redirected to the new user registration flow, creating duplicate accounts.

  ## TO-BE
  - OAuth accounts are identified by the provider’s immutable user identifier.
  - Account lookup uses `provider_type + provider_id`.
  - Email is treated as profile data, not as the account identifier.
  - Existing users are logged into their previously linked account even if the provider email
  changes.