### PR TITLE
Fix reply masking sender verification

### DIFF
--- a/back-end/.env.example
+++ b/back-end/.env.example
@@ -34,3 +34,7 @@ AWS_SQS_QUEUE_URL=https://sqs.region.amazonaws.com/account-id/queue-name
 
 # CORS Configuration
 CORS_ORIGINS=http://localhost:3000,http://localhost:8080
+
+# Data Protection
+ENCRYPTION_KEY=base64-encoded-32-byte-key
+REPLY_MASK_HMAC_KEY=base64-encoded-32-byte-key

--- a/back-end/src/common/utils/protection.util.ts
+++ b/back-end/src/common/utils/protection.util.ts
@@ -11,9 +11,11 @@ export class ProtectionUtil {
   private readonly DIGEST = 'hex';
   private readonly IV_LENGTH = 16; // 16 bytes for AES
   private readonly SECRET_KEY: string;
+  private readonly HMAC_SECRET_KEY: string;
 
   constructor(customEnvService: CustomEnvService) {
     this.SECRET_KEY = customEnvService.get<string>('ENCRYPTION_KEY');
+    this.HMAC_SECRET_KEY = customEnvService.get<string>('REPLY_MASK_HMAC_KEY');
   }
 
   /**
@@ -100,6 +102,21 @@ export class ProtectionUtil {
    */
   hash(plain: string): string {
     return crypto.createHash(this.HASH_ALGORITHM).update(plain).digest(this.DIGEST);
+  }
+
+  /**
+   * Sign data using HMAC-SHA256.
+   * @param plain - text to sign
+   * @returns HMAC digest as a lowercase hexadecimal string
+   */
+  hmac(plain: string): string {
+    const keyBuffer = Buffer.from(this.HMAC_SECRET_KEY, this.ENCODE_ALGORITHM);
+
+    if (keyBuffer.length !== 32) {
+      throw new InternalServerErrorException('HMAC key must be 32 bytes (256 bits)');
+    }
+
+    return crypto.createHmac(this.HASH_ALGORITHM, keyBuffer).update(plain).digest(this.DIGEST);
   }
 
   /**

--- a/back-end/src/config/env.validation.ts
+++ b/back-end/src/config/env.validation.ts
@@ -85,6 +85,9 @@ class EnvironmentVariables {
 
   @IsString()
   ENCRYPTION_KEY: string;
+
+  @IsString()
+  REPLY_MASK_HMAC_KEY: string;
 }
 
 export function validate(config: Record<string, unknown>) {

--- a/back-end/src/relay-emails/relay-emails.service.ts
+++ b/back-end/src/relay-emails/relay-emails.service.ts
@@ -259,12 +259,33 @@ export class RelayEmailsService {
         const replyMasking = await this.replyMaskEmailService.findByReplyAddress(recipientEmail);
 
         if (!replyMasking) {
-          this.logger.error(`No reply masking entity found for address: ${recipientEmail}`);
+          this.logger.warn('Rejected reply for an unknown masking address');
           return;
         }
 
         const originalSender = this.encryptionUtil.decrypt(replyMasking.senderAddress);
         const relayAddress = this.encryptionUtil.decrypt(replyMasking.receiverAddress);
+        const relayEmailEntity = await this.relayEmailRepository.findOne({
+          where: { relayEmail: relayAddress },
+        });
+
+        if (!relayEmailEntity || !relayEmailEntity.isActive) {
+          this.logger.warn('Rejected reply for an unknown or inactive relay address');
+          return;
+        }
+
+        const replySender = this.getReplySender(parsedMail);
+        if (!replySender) {
+          this.logger.warn('Rejected reply without exactly one valid From address');
+          return;
+        }
+
+        const primaryEmail = this.encryptionUtil.decrypt(relayEmailEntity.primaryEmail);
+        if (replySender !== this.normalizeEmailAddress(primaryEmail)) {
+          this.logger.warn('Rejected reply from an unauthorized sender');
+          return;
+        }
+
         const dbElapsed = Date.now() - dbStartTime;
 
         const forwardStartTime = Date.now();
@@ -646,6 +667,25 @@ export class RelayEmailsService {
       this.logger.error(`Failed to parse sender from email: ${error.message}`, error.stack);
       throw error;
     }
+  }
+
+  private getReplySender(mail: ParsedMail): string | null {
+    const fromAddresses = mail.from?.value;
+
+    if (!fromAddresses || fromAddresses.length !== 1) {
+      return null;
+    }
+
+    const address = fromAddresses[0]?.address;
+    if (!address) {
+      return null;
+    }
+
+    return this.normalizeEmailAddress(address);
+  }
+
+  private normalizeEmailAddress(address: string): string {
+    return address.trim().toLowerCase();
   }
 
   // parse relay email address

--- a/back-end/src/relay-emails/reply-emails.service.ts
+++ b/back-end/src/relay-emails/reply-emails.service.ts
@@ -22,7 +22,9 @@ export class ReplyEmailsService {
     });
   }
   async create(sender: string, receiver: string): Promise<ReplyMasking> {
-    const replyAddress = this.generateReplyMaskingEmail(sender, receiver);
+    const normalizedSender = this.normalizeEmailAddress(sender);
+    const normalizedReceiver = this.normalizeEmailAddress(receiver);
+    const replyAddress = this.generateReplyMaskingEmail(normalizedSender, normalizedReceiver);
 
     // check if its existing
     const existing = await this.replyMaskingRepository.findOne({ where: { replyAddress } });
@@ -34,17 +36,22 @@ export class ReplyEmailsService {
     // create
     const entity = this.replyMaskingRepository.create({
       replyAddress,
-      senderAddress: this.protectionUtil.encrypt(sender),
-      senderAddressHash: this.protectionUtil.hash(sender),
-      receiverAddress: this.protectionUtil.encrypt(receiver),
-      receiverAddressHash: this.protectionUtil.hash(receiver),
+      senderAddress: this.protectionUtil.encrypt(normalizedSender),
+      senderAddressHash: this.protectionUtil.hashEmailAddress(normalizedSender),
+      receiverAddress: this.protectionUtil.encrypt(normalizedReceiver),
+      receiverAddressHash: this.protectionUtil.hashEmailAddress(normalizedReceiver),
     });
 
     return this.replyMaskingRepository.save(entity);
   }
 
   private generateReplyMaskingEmail(sender: string, receiver: string): string {
-    const domain = this.customEnvService.get<string>('APP_DOMAIN') || 'private-mailhub.com';
-    return 'reply-'.concat(this.protectionUtil.hash(`${sender}:${receiver}`)).concat(`@${domain}`);
+    const domain = this.customEnvService.get<string>('APP_DOMAIN');
+    const signature = this.protectionUtil.hmac(`${sender}:${receiver}`);
+    return `reply-${signature}@${domain}`;
+  }
+
+  private normalizeEmailAddress(address: string): string {
+    return address.trim().toLowerCase();
   }
 }

--- a/back-end/test/common/utils/protection.util.spec.ts
+++ b/back-end/test/common/utils/protection.util.spec.ts
@@ -180,6 +180,48 @@ describe('ProtectionUtil', () => {
   });
 
   // ─────────────────────────────────────────────
+  // hmac
+  // ─────────────────────────────────────────────
+  describe('hmac', () => {
+    it('returns a deterministic HMAC-SHA256 digest', () => {
+      const plainText = 'sender@example.com:relay@example.com';
+      const expected = crypto
+        .createHmac('sha256', Buffer.from(VALID_KEY, 'base64'))
+        .update(plainText)
+        .digest('hex');
+
+      const result = protectionUtil.hmac(plainText);
+
+      expect(result).toBe(expected);
+      expect(result).toHaveLength(64);
+      expect(result).toMatch(/^[0-9a-f]+$/);
+      expect(protectionUtil.hmac(plainText)).toBe(result);
+    });
+
+    it('returns different digests for different inputs', () => {
+      expect(protectionUtil.hmac('first')).not.toBe(protectionUtil.hmac('second'));
+    });
+
+    it('returns different digests for different keys', () => {
+      const otherKey = Buffer.alloc(32, 1).toString('base64');
+      const otherEnvService = {
+        get: jest.fn().mockReturnValue(otherKey),
+      } as unknown as jest.Mocked<CustomEnvService>;
+      const otherUtil = new ProtectionUtil(otherEnvService);
+
+      expect(protectionUtil.hmac('same-input')).not.toBe(otherUtil.hmac('same-input'));
+    });
+
+    it('rejects a key that is not 32 bytes', () => {
+      customEnvService.get.mockReturnValue('invalid-key');
+      const util = new ProtectionUtil(customEnvService);
+
+      expect(() => util.hmac('plain-text')).toThrow(InternalServerErrorException);
+      expect(() => util.hmac('plain-text')).toThrow('HMAC key must be 32 bytes');
+    });
+  });
+
+  // ─────────────────────────────────────────────
   // hashEmailAddress
   // ─────────────────────────────────────────────
   describe('hashEmailAddress', () => {

--- a/back-end/test/relay-emails/relay-emails.service.spec.ts
+++ b/back-end/test/relay-emails/relay-emails.service.spec.ts
@@ -1,0 +1,144 @@
+import { Repository } from 'typeorm';
+import { CacheService } from 'src/cache/cache.service';
+import { CustomEnvService } from 'src/config/custom-env.service';
+import { ProtectionUtil } from 'src/common/utils/protection.util';
+import { EmailForwardingLogService } from 'src/logs/email-forwarding-log.service';
+import { SendMailService } from 'src/mail/send-mail.service';
+import { S3Service } from 'src/aws/s3/s3.service';
+import { S3EventRecord, SqsService } from 'src/aws/sqs/sqs.service';
+import { RelayEmail } from 'src/relay-emails/entities/relay-email.entity';
+import { ReplyMasking } from 'src/relay-emails/entities/reply-masking.entity';
+import { RelayEmailsService } from 'src/relay-emails/relay-emails.service';
+import { ReplyEmailsService } from 'src/relay-emails/reply-emails.service';
+
+describe('RelayEmailsService reply authorization', () => {
+  const relayAddress = 'relay@example.com';
+  const replyAddress = 'reply-token@example.com';
+  const record = {
+    s3: {
+      bucket: { name: 'email-bucket' },
+      object: { key: 'message.eml' },
+    },
+  } as S3EventRecord;
+
+  let service: RelayEmailsService;
+  let relayEmailRepository: jest.Mocked<Repository<RelayEmail>>;
+  let s3Service: jest.Mocked<S3Service>;
+  let sendMailService: jest.Mocked<SendMailService>;
+  let replyEmailsService: jest.Mocked<ReplyEmailsService>;
+  let sendMailMock: jest.Mock;
+  let incrementForwardCountSpy: jest.SpiedFunction<RelayEmailsService['incrementForwardCount']>;
+
+  beforeEach(() => {
+    relayEmailRepository = {
+      findOne: jest.fn().mockResolvedValue({
+        relayEmail: relayAddress,
+        primaryEmail: 'encrypted-primary',
+        isActive: true,
+      } as RelayEmail),
+    } as unknown as jest.Mocked<Repository<RelayEmail>>;
+    s3Service = {
+      getObject: jest.fn(),
+    } as unknown as jest.Mocked<S3Service>;
+    sendMailMock = jest.fn();
+    sendMailService = {
+      sendMail: sendMailMock,
+    } as unknown as jest.Mocked<SendMailService>;
+    replyEmailsService = {
+      findByReplyAddress: jest.fn().mockResolvedValue({
+        senderAddress: 'encrypted-original-sender',
+        receiverAddress: 'encrypted-relay',
+      } as ReplyMasking),
+    } as unknown as jest.Mocked<ReplyEmailsService>;
+    const protectionUtil = {
+      decrypt: jest.fn((value: string) => {
+        const decrypted = {
+          'encrypted-original-sender': 'original@example.net',
+          'encrypted-relay': relayAddress,
+          'encrypted-primary': 'owner@example.com',
+        };
+        return decrypted[value];
+      }),
+    } as unknown as jest.Mocked<ProtectionUtil>;
+
+    service = new RelayEmailsService(
+      relayEmailRepository,
+      {} as CustomEnvService,
+      replyEmailsService,
+      s3Service,
+      {} as SqsService,
+      sendMailService,
+      {} as CacheService,
+      protectionUtil,
+      {} as EmailForwardingLogService,
+    );
+    incrementForwardCountSpy = jest.spyOn(service, 'incrementForwardCount').mockResolvedValue();
+  });
+
+  function setMailHeaders(fromHeaders: string): void {
+    const rawEmail = [fromHeaders, `To: ${replyAddress}`, 'Subject: Reply', '', 'Reply body'].join(
+      '\r\n',
+    );
+    s3Service.getObject.mockResolvedValue(Buffer.from(rawEmail));
+  }
+
+  async function processRecord(): Promise<void> {
+    await service['processS3Record'](record);
+  }
+
+  it('forwards a reply when the canonical From address matches the primary email', async () => {
+    setMailHeaders('From: "Account Owner" <Owner@Example.COM>');
+
+    await processRecord();
+
+    expect(sendMailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'original@example.net',
+        from: relayAddress,
+      }),
+    );
+    expect(incrementForwardCountSpy).toHaveBeenCalledWith(relayAddress);
+  });
+
+  it.each([
+    ['a different address', 'From: attacker@example.com'],
+    ['a plus-address variant', 'From: owner+tag@example.com'],
+  ])('rejects %s', async (_, fromHeader) => {
+    setMailHeaders(fromHeader);
+
+    await processRecord();
+
+    expect(sendMailMock).not.toHaveBeenCalled();
+    expect(incrementForwardCountSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['a missing From address', 'Return-Path: <owner@example.com>'],
+    ['multiple From addresses', 'From: owner@example.com, attacker@example.com'],
+  ])('rejects replies with %s', async (_, fromHeaders) => {
+    setMailHeaders(fromHeaders);
+
+    await processRecord();
+
+    expect(sendMailMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['an unknown relay address', null],
+    [
+      'an inactive relay address',
+      {
+        relayEmail: relayAddress,
+        primaryEmail: 'encrypted-primary',
+        isActive: false,
+      } as RelayEmail,
+    ],
+  ])('rejects replies for %s', async (_, relayEmail) => {
+    relayEmailRepository.findOne.mockResolvedValue(relayEmail);
+    setMailHeaders('From: owner@example.com');
+
+    await processRecord();
+
+    expect(sendMailMock).not.toHaveBeenCalled();
+  });
+});

--- a/back-end/test/relay-emails/reply-emails.service.spec.ts
+++ b/back-end/test/relay-emails/reply-emails.service.spec.ts
@@ -1,0 +1,65 @@
+import { Repository } from 'typeorm';
+import { ProtectionUtil } from 'src/common/utils/protection.util';
+import { CustomEnvService } from 'src/config/custom-env.service';
+import { ReplyMasking } from 'src/relay-emails/entities/reply-masking.entity';
+import { ReplyEmailsService } from 'src/relay-emails/reply-emails.service';
+
+describe('ReplyEmailsService', () => {
+  let service: ReplyEmailsService;
+  let repository: jest.Mocked<Repository<ReplyMasking>>;
+  let protectionUtil: jest.Mocked<ProtectionUtil>;
+  let createMock: jest.Mock;
+  let saveMock: jest.Mock;
+  let hmacMock: jest.Mock;
+
+  beforeEach(() => {
+    createMock = jest.fn((entity) => entity as ReplyMasking);
+    saveMock = jest.fn((entity) => Promise.resolve(entity as ReplyMasking));
+    repository = {
+      findOne: jest.fn(),
+      create: createMock,
+      save: saveMock,
+    } as unknown as jest.Mocked<Repository<ReplyMasking>>;
+    hmacMock = jest.fn(() => 'signature');
+    protectionUtil = {
+      encrypt: jest.fn((value: string) => `encrypted:${value}`),
+      hashEmailAddress: jest.fn((value: string) => `hash:${value}`),
+      hmac: hmacMock,
+    } as unknown as jest.Mocked<ProtectionUtil>;
+    const customEnvService = {
+      get: jest.fn().mockReturnValue('private-mailhub.com'),
+    } as unknown as jest.Mocked<CustomEnvService>;
+
+    service = new ReplyEmailsService(repository, protectionUtil, customEnvService);
+  });
+
+  it('normalizes addresses before creating an HMAC reply address', async () => {
+    repository.findOne.mockResolvedValue(null);
+
+    const result = await service.create(' Sender@Example.COM ', ' Relay@Example.COM ');
+
+    expect(hmacMock).toHaveBeenCalledWith('sender@example.com:relay@example.com');
+    expect(createMock).toHaveBeenCalledWith({
+      replyAddress: 'reply-signature@private-mailhub.com',
+      senderAddress: 'encrypted:sender@example.com',
+      senderAddressHash: 'hash:sender@example.com',
+      receiverAddress: 'encrypted:relay@example.com',
+      receiverAddressHash: 'hash:relay@example.com',
+    });
+    expect(saveMock).toHaveBeenCalled();
+    expect(result.replyAddress).toBe('reply-signature@private-mailhub.com');
+  });
+
+  it('returns an existing reply masking record without creating another one', async () => {
+    const existing = {
+      id: 1n,
+      replyAddress: 'reply-signature@private-mailhub.com',
+    } as ReplyMasking;
+    repository.findOne.mockResolvedValue(existing);
+
+    await expect(service.create('sender@example.com', 'relay@example.com')).resolves.toBe(existing);
+
+    expect(createMock).not.toHaveBeenCalled();
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- verify that replies sent to masking addresses come from the relay owner's primary email
- reject missing, multiple, mismatched, plus-address, unknown, and inactive senders without forwarding
- generate new reply masking addresses with HMAC-SHA256 and a dedicated `REPLY_MASK_HMAC_KEY`
- add unit coverage for HMAC generation and reply authorization

## Root cause

Reply masking addresses were deterministic SHA-256 hashes and the reply path did not verify the incoming `From` address. Anyone who obtained or predicted a masking address could send mail that appeared to originate from the associated relay address.

## Developer impact

`REPLY_MASK_HMAC_KEY` is now a required environment variable. It must be a Base64-encoded 32-byte key and must be configured before deployment. Existing stored masking addresses remain valid; newly generated addresses use HMAC-SHA256.

## Validation

- `npm test -- --runInBand` — 45 tests passed
- changed-file ESLint — passed
- `npx nest build` — passed
- `git diff --check` — passed

Closes #21
